### PR TITLE
remove api generator fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "hexo": "^3.0.0",
     "hexo-deployer-git": "0.0.3",
-    "hexo-generator-api": "^0.1.0",
     "hexo-generator-archive": "^0.1.0",
     "hexo-generator-category": "^0.1.0",
     "hexo-generator-feed": "^1.0.1",


### PR DESCRIPTION
fixes problems to generate the blog files // api generator plugin has not been updated to be used in hexo 3.0.0. Before I used it from another repo (submitted PR to fix it), but it got lost on the way. Api generator is no longer needed, so instead of adding a different version, I completely remove it.
